### PR TITLE
search bar - allow results to show up even if one search result doesn't have an image or an ISBN-10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+server/secrets

--- a/client/components/Book.js
+++ b/client/components/Book.js
@@ -9,12 +9,14 @@ export default function Book(props) {
   const updateUser = useStoreActions((actions) => actions.updateUser);
   const likedBooks = useStoreState((state) => state.userLikedBooks);
   const updateLikedBooks = useStoreActions((actions) => actions.updateLikedBooks);
-  const imageUrls = Object.values(props.book.volumeInfo.imageLinks);
+  const imageUrl = props.book.volumeInfo.imageLinks ? Object.values(props.book.volumeInfo.imageLinks)[0] : "not found";
+  const isbn = props.book.volumeInfo.industryIdentifiers[1] ? props.book.volumeInfo.industryIdentifiers[1].identifier : props.book.volumeInfo.industryIdentifiers[0].identifier
+  const isbn_type = props.book.volumeInfo.industryIdentifiers[1] ? props.book.volumeInfo.industryIdentifiers[1].type : props.book.volumeInfo.industryIdentifiers[0].type
   const bookData = {
     name: props.book.volumeInfo.title,
     description: props.book.volumeInfo.description,
-    isbn: props.book.volumeInfo.industryIdentifiers[1].identifier,
-    imageUrl: imageUrls[0],
+    isbn: isbn, // props.book.volumeInfo.industryIdentifiers[1].identifier,
+    imageUrl: imageUrl,
     moreInfo: props.book.volumeInfo.infoLink
   }
 
@@ -34,12 +36,11 @@ export default function Book(props) {
 
   }
 
-
   return (
     <div>
       <h4>Book Name: {bookData.name} </h4>
-      <img src={imageUrls[0]} />
-      <h4>ISBN-10: {bookData.isbn}</h4>
+      <img src={bookData.imageUrl} />
+      <h4>{isbn_type}: {bookData.isbn}</h4>
 
       <h4>Description: {bookData.description}</h4>
       <a href={bookData.moreInfo}>More Info</a>

--- a/server/model/schema.js
+++ b/server/model/schema.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const { schema } = require("webpack-dev-server");
-const MONGO_URI = `mongodb+srv://hmu1540:Gt7130mhm%40%40@cluster0.8mkig.mongodb.net/?retryWrites=true&w=majority`;
+const {password} = require('../secrets')
+const MONGO_URI = `mongodb+srv://username:${password}@booksrus-2.zrev2wj.mongodb.net/?retryWrites=true&w=majority`;
 mongoose.connect(MONGO_URI, {
   // options for the connect method to parse the URI
   useNewUrlParser: true,


### PR DESCRIPTION
<img width="1058" alt="Screen Shot 2022-08-02 at 2 25 11 PM" src="https://user-images.githubusercontent.com/85897001/182476152-c0948bba-9684-41a3-9a3f-bf92a34454c9.png">
currently, books without images render like this - do we want to change this?

